### PR TITLE
Declare vars for string constants to avoid strict mode errors.

### DIFF
--- a/css_grid_annotator.js
+++ b/css_grid_annotator.js
@@ -16,10 +16,10 @@ function cssGridAnnotate() {
     return;
   }
 
-  CSS_DISPLAY_GRID = "-ms-grid";
-  CSS_TEMPLATE_COLS = "-ms-grid-columns";
-  CSS_ROW = "-ms-grid-row";
-  CSS_COL = "-ms-grid-column";
+  var CSS_DISPLAY_GRID = "-ms-grid";
+  var CSS_TEMPLATE_COLS = "-ms-grid-columns";
+  var CSS_ROW = "-ms-grid-row";
+  var CSS_COL = "-ms-grid-column";
 
   function annotateAll(parentElement) {
     // we have to go through every single element to check the computed style


### PR DESCRIPTION
Was getting strict mode errors in ie11 without the string constants explicitly declared as vars.